### PR TITLE
Fix url encoding issues for &

### DIFF
--- a/index.js
+++ b/index.js
@@ -1794,7 +1794,7 @@ module.query = function(context, entity, criteria, callback) {
   }
   if (criteria && typeof criteria !== 'function') {
     url += module.criteriaToString(criteria) || ''
-    url = url.replace(/'/g, '%27').replace(/=/, '%3D').replace(/</, '%3C').replace(/>/, '%3E')
+    url = url.replace(/'/g, '%27').replace(/=/, '%3D').replace(/</, '%3C').replace(/>/, '%3E').replace(/\&/g, '%26');
   }
   url = url.replace('@@', '=')
   module.request(context, 'get', {url: url}, null, typeof criteria === 'function' ? criteria : callback)


### PR DESCRIPTION
 - & has to be converted to %26 in order for queries to work in Quickbooks. Found this bug while querying a customer's name.

Example code that causes the bug:
```javascript
      var QuickBooks = require('node-quickbooks');
      var config = require('../config');
      var qbo = new QuickBooks(config);

      var query = [
        {field: 'DisplayName', value: 'AT&T', operator: '='}
      ];

      qbo.findCustomers(query, function(e, findResult) {
          console.log('Find Result: ', findResult);
      });
```

Quickbooks returns 2050 ValidationFault error at the & sign without this fix.