### PR TITLE
Write PDF not working

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,4 +9,6 @@ module.exports = {
   //
   // Set useSandbox to false when moving to production. For info, see the following url:
   // https://developer.intuit.com/v2/blog/2014/10/24/intuit-developer-now-offers-quickbooks-sandboxes
+  
+  testEmail:       ''  // Use this email address for testing send*Pdf functions
 }

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ module.exports = {
   tokenSecret:     '',
   realmId:         '',
   useSandbox:      true,
-  debug:           false
+  debug:           false,
   //
   // Set useSandbox to false when moving to production. For info, see the following url:
   // https://developer.intuit.com/v2/blog/2014/10/24/intuit-developer-now-offers-quickbooks-sandboxes

--- a/index.js
+++ b/index.js
@@ -1734,6 +1734,7 @@ module.request = function(context, verb, options, entity, callback) {
   }
   if (options.url.match(/pdf$/)) {
     opts.headers['accept'] = 'application/pdf'
+    opts.encoding = null
   }
   if (entity !== null) {
     opts.body = entity

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "util": "0.10.3"
   },
   "devDependencies": {
-    "mocha": "1.21.3",
+    "mocha": "2.2.5",
     "expect": "0.1.1",
     "async": "0.9.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -167,12 +167,13 @@ describe('SalesReceipt', function() {
       expect(err).toBe(null)
       expect(salesReceipt.Fault).toBe(undefined)
       async.series([function(cb) {
-        qbo.sendSalesReceiptPdf(salesReceipt.Id, 'mcohen01@gmail.com', function(err, data) {
+        qbo.sendSalesReceiptPdf(salesReceipt.Id, config.testEmail, function(err, data) {
           console.log(util.inspect(data, {showHidden: false, depth: null}));
           cb()
         })
       }, function(cb) {
         qbo.getSalesReceiptPdf(salesReceipt.Id, function(err, data) {
+          fs.writeFileSync('salesReceipt_'+salesReceipt.Id+'.pdf',data);
           console.log(util.inspect(data, {showHidden: false, depth: null}));
           cb()
         })

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
-var fs         = require('fs'),
+var os         = require('os'), 
+    fs         = require('fs'),
     util       = require('util'),
     expect     = require('expect'),
     async      = require('async'),
@@ -99,7 +100,7 @@ describe('Query', function() {
     })
   })
 
-  var queries = fs.readFileSync('build/query.txt').toString('utf-8').split('\n')
+  var queries = fs.readFileSync('build/query.txt').toString('utf-8').split(os.EOL)
   queries.forEach(function(q) {
     it('should fetch ' + qbo.capitalize(q), function (done) {
       qbo['find' +  qbo.pluralize(qbo.capitalize(q))].call(qbo, function(err, data) {
@@ -118,7 +119,7 @@ describe('Reports', function() {
 
   this.timeout(30000);
 
-  var reports = fs.readFileSync('build/report.txt').toString('utf-8').split('\n')
+  var reports = fs.readFileSync('build/report.txt').toString('utf-8').split(os.EOL)
   reports.some(function (line) {
     if (line === '') return true
     it('should fetch ' + line + ' Report', function (done) {


### PR DESCRIPTION
The get*Pdf routines return the response body as a string.  When this string is written to a PDF file, the PDF file is present but is blank when opened with a reader.  The fix is to set the QB request encoding to null so that the response body is returned as a buffer. (index.js)

The rest of the changes center around the test suite.  I added a file write to sendSalesReceipt test to validate the bug and the fix.  I added a testEmail property to the config so that I sent myself the emails when running the test suite.  When I ran the suite in Windows, mocha kicked out a depricated child_process.spawn customFds error, which has been fixed in a later release so I upgraded mocha in the package.json.  I also had to change the EOL to get the file based tests to work, so I updated the suite to use os.EOL (and now it passes in both Windows & Linux).