### PR TITLE
Changed references of Intuit Partner Program to Intuit Developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,18 +129,18 @@ Start the app
 
     node app.js
 
-Browse to http://localhost:3000/start and you will see a page containing only the IPP Javascript-rendered button.  Clicking on this kicks off the OAuth exchange.
+Browse to http://localhost:3000/start and you will see a page containing only the Intuit Developer Javascript-rendered button.  Clicking on this kicks off the OAuth exchange.
 
-The IPP Javascript code calls back into the node application, which needs to invoke the OAuth Request Token URL at https://oauth.intuit.com/oauth/v1/get_request_token via a server-side http POST method. Note how the response from the http POST is parsed and the browser is redirected to the App Center URL at https://appcenter.intuit.com/Connect/Begin?oauth_token= with the `oauth_token` passed as a URL parameter. Note also how the `oauth_token_secret` needs to somehow be maintained across http requests, as it needs to be passed in the second server-side http POST to the Access Token URL at https://oauth.intuit.com/oauth/v1/get_access_token. This final step is invoked once the user has authenticated on Intuit's site and authorized the application, and then the user is redirected back to the node application at the callback URL specified as a parameter in the Request Token remote call, in the example app's case, http://localhost:3000/callback.
+The Intuit Developer Javascript code calls back into the node application, which needs to invoke the OAuth Request Token URL at https://oauth.intuit.com/oauth/v1/get_request_token via a server-side http POST method. Note how the response from the http POST is parsed and the browser is redirected to the App Center URL at https://appcenter.intuit.com/Connect/Begin?oauth_token= with the `oauth_token` passed as a URL parameter. Note also how the `oauth_token_secret` needs to somehow be maintained across http requests, as it needs to be passed in the second server-side http POST to the Access Token URL at https://oauth.intuit.com/oauth/v1/get_access_token. This final step is invoked once the user has authenticated on Intuit's site and authorized the application, and then the user is redirected back to the node application at the callback URL specified as a parameter in the Request Token remote call, in the example app's case, http://localhost:3000/callback.
 
 ### Configuration
 
-The IPP Javascript code contained in `intuit.ejs` is configured with the `grantUrl` option set to "http://localhost:3000/requestToken". You will want to change this to an appropriate URL for your application, but you will need to write similar functionality to that contained in the  '/requestToken' route configured in `app.js`, also taking care to configure your `consumerKey` and `consumerSecret` on lines 27-28 in app.js.
+The Intuit Developer Javascript code contained in `intuit.ejs` is configured with the `grantUrl` option set to "http://localhost:3000/requestToken". You will want to change this to an appropriate URL for your application, but you will need to write similar functionality to that contained in the  '/requestToken' route configured in `app.js`, also taking care to configure your `consumerKey` and `consumerSecret` on lines 27-28 in app.js.
 
 
 ## Running the tests
 
-First you'll need to fill in the missing values in config.js. The consumerKey and consumerSecret you can get from the IPP portal, the token, tokenSecret, and realmId are easiest to obtain by running the example app, completing the OAuth workflow, and copying the values that are logged to the console. Once you've filled in the missing credentials in config.js you can simply run:
+First you'll need to fill in the missing values in config.js. The consumerKey and consumerSecret you can get from the Intuit Developer portal, the token, tokenSecret, and realmId are easiest to obtain by running the example app, completing the OAuth workflow, and copying the values that are logged to the console. Once you've filled in the missing credentials in config.js you can simply run:
 
 `npm test`
 

--- a/example/package.json
+++ b/example/package.json
@@ -15,6 +15,7 @@
     "cookie-parser": "^1.3.5",
     "ejs": "0.7.2",
     "express": "^4.13.3",
+    "express-session": "^1.11.3",
     "node-quickbooks": "1.0.19"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -1,12 +1,12 @@
 {
   "name": "node-quickbooks-example-app",
   "version": "0.0.1",
-  "description": "Example Express application for Intuit's node.js client for IPP QuickBooks V3 API.",
+  "description": "Example Express application for Intuit's node.js client for QuickBooks V3 API.",
   "main": "app.js",
   "keywords": [
     "Intuit",
     "QuickBooks",
-    "IPP"
+    "Intuit Developer"
   ],
   "author": "Michael Cohen",
   "license": "ISC",


### PR DESCRIPTION
The IPP branding was dropped a while ago, replacing with 'Intuit Developer' should match the current Intuit Developer portal and decrease confusion. 