### PR TITLE
Update request dependency to 2.67.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "moment": "^2.8.2",
     "node-uuid": "^1.4.1",
     "querystring": "0.2.0",
-    "request": "2.39.0",
+    "request": "2.67.1",
     "request-debug": "0.0.1",
     "underscore": "1.6.0",
     "util": "0.10.3"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "moment": "^2.8.2",
     "node-uuid": "^1.4.1",
     "querystring": "0.2.0",
-    "request": "2.67.1",
+    "request": "2.67.0",
     "request-debug": "0.0.1",
     "underscore": "1.6.0",
     "util": "0.10.3"


### PR DESCRIPTION
request@2.39.0 uses a vulnerable version of qs according to node security project


<img width="770" alt="screen shot 2015-12-01 at 4 23 06 pm" src="https://cloud.githubusercontent.com/assets/3885959/11517663/24fffb2c-9848-11e5-8fea-b8711bff7dc0.png">

request@2.67.0 has updated that qs dependency and is no longer vulnerable


<img width="801" alt="screen shot 2015-12-01 at 4 23 38 pm" src="https://cloud.githubusercontent.com/assets/3885959/11517673/36c4aac4-9848-11e5-8a4d-0b3009ca7cb0.png">


