### PR TITLE
Add getExchangeRate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ __Arguments__
 * [`getTimeActivity`](#getTimeActivity)
 * [`getVendor`](#getVendor)
 * [`getVendorCredit`](#getVendorCredit)
+* [`getExchangeRate`](#getExchangeRate)
 
 #### Update
 
@@ -812,6 +813,17 @@ __Arguments__
 
 * `id` - The Id of persistent Estimate
 * `callback` - Callback function which is called with any error and the persistent Estimate
+
+
+<a name="getExchangeRate" />
+#### getExchangeRate(options, callback)
+
+Retrieves an ExchangeRate from QuickBooks
+
+__Arguments__
+
+* `options` -  An object with options including the required `sourcecurrencycode` parameter and optional `asofdate` parameter.
+* `callback` - Callback function which is called with any error and the ExchangeRate
 
 
 <a name="getInvoice" />

--- a/index.js
+++ b/index.js
@@ -514,6 +514,17 @@ QuickBooks.prototype.getEstimate = function(id, callback) {
 }
 
 /**
+ * Retrieves an ExchangeRate from QuickBooks
+ *
+ * @param  {object} options - An object with options including the required `sourcecurrencycode` parameter and optional `asofdate` parameter.
+ * @param  {function} callback - Callback function which is called with any error and the ExchangeRate
+ */
+QuickBooks.prototype.getExchangeRate = function(options, callback) {
+  var url = "/exchangerate";
+  module.request(this, 'get', {url: url, qs: options}, null, callback)
+}
+
+/**
  * Emails the Estimate PDF from QuickBooks to the address supplied in Estimate.BillEmail.EmailAddress
  * or the specified 'sendTo' address
  *


### PR DESCRIPTION
Currently, this library has methods to update exchange rates as well as find (query) exchange rates (requested in #47; added in 8da5a314f8cbeef38f56f4b5ef3a6f5be5d1f14f). However, a method to retrieve a single ExchangeRate is missing.

SIdenote: I've simply been using the findExchangeRates method with a `limit` of `1`, and `desc`'d on the `MetaData.LastUpdatedTime` value. Unfortunately, [Quickbooks has a bug](https://intuitdeveloper.lc.intuit.com/questions/1389462-do-get-requests-to-exchangerate-endpoint-still-work?jump_to=answer_3054709) that has affected the ability to query for exchange rates. The prescribed workaround is to fetch single exchange rates (which is what this PR adds).

Unfortunately, this endpoint somehow has a completely url pattern: instead of being `/exchangerate/:id` (where `id` is the mandatory `sourcecurrencycode` value), it is instead `/exchangerate? sourcecurrencycode=code&asofdate=whatever` 🙊. As such, I had to use `module.request` directly, instead of `module.read`. Hopefully you find this deviation from the other `get` methods okay.