### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  */
 
 var request = require('request'),
-    uuid    = require('node-uuid'),
+    uuid    = require('uuid'),
     debug   = require('request-debug'),
     util    = require('util'),
     moment  = require('moment'),

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "dependencies": {
     "bluebird": "2.9.25",
     "moment": "^2.8.2",
-    "node-uuid": "^1.4.1",
     "querystring": "0.2.0",
     "request": "2.74.0",
     "request-debug": "0.0.1",
     "underscore": "1.6.0",
-    "util": "0.10.3"
+    "util": "0.10.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "2.2.5",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.