### PR TITLE
fixed bug where some errors are sent as XML

### DIFF
--- a/index.js
+++ b/index.js
@@ -1963,6 +1963,7 @@ module.request = function(context, verb, options, entity, callback) {
   opts.qs.minorversion = opts.qs.minorversion || 4
   opts.headers['User-Agent'] = 'node-quickbooks: version ' + version
   opts.headers['Request-Id'] = uuid.v1()
+  opts.qs.format = 'json';
   if (options.url.match(/pdf$/)) {
     opts.headers['accept'] = 'application/pdf'
     opts.encoding = null


### PR DESCRIPTION
The API has a weird bug where the response is sent in XML if there is a Token Authorization or some other header related error.
This change is a workaround which solves that problem by setting the response format in the request url.