### PR TITLE
Fix single quote escape bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -2241,7 +2241,7 @@ module.criteriaToString = function(criteria) {
     }
     sql += criterion.field + ' ' + criterion.operator + ' '
     var quote = function(x) {
-      return _.isString(x) ? "'" + x + "'" : x
+      return _.isString(x) ? "'" + x.replace(/'/g, "\\'") + "'" : x
     }
     if (_.isArray(criterion.value)) {
       sql += '(' + criterion.value.map(quote).join(',') + ')'


### PR DESCRIPTION
When you query for an item that has single quote(s) in any position, the following error would occur:

`QueryParserError: Encountered " "s "" at line 1, column 115. Was expecting one of: ... "iterator" ... "maxresults" ... ... "order" ... "orderby" ... "startposition" ...`

I have looked through the URL building logic and realized that problem is in `criteriaToString` method. When you pass into it the following criteria:

`{Name: 'Men\'s Helmet'}`

The output would be:

`/query?query@@select * from item where Name = 'Men's Helmet' startposition 1 maxresults 1000`

If backslash is not forced in the query, QuickBooks won't be able to parse the string properly.