### PR TITLE
Remove console.log statement from refreshAccessToken

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,6 @@ QuickBooks.prototype.refreshAccessToken = function(callback) {
 
     request.post(postBody, function (e, r, data) {
         var refreshResponse = JSON.parse(r.body);
-        console.log(refreshResponse);
         this.refreshToken = refreshResponse.refresh_token;
         this.token = refreshResponse.access_token;
         callback(refreshResponse, e);


### PR DESCRIPTION
Logging the refreshAccessToken to the console as done in #96 presents an exposure risk of unencrypted OAuth 2.0 access tokens, which violates [Intuit Security Requirements](https://developer.intuit.com/docs/00_quickbooks_online/4_go_live/30_publish_to_app_store/30_security_requirements):

> You must not log any user’s credentials or QuickBooks data.

> Encrypt and store the refresh token and realmId in persistent memory.