### PR TITLE
Revert "add a method to refresh the access token given the refresh token."

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,39 +99,6 @@ function QuickBooks(consumerKey, consumerSecret, token, tokenSecret, realmId, us
 }
 
 /**
- *
- * Use the refresh token to obtain a new access token.
- *
- *
- */
-
-QuickBooks.prototype.refreshAccessToken = function(callback) {
-    var auth = (new Buffer(this.consumerKey + ':' + this.consumerSecret).toString('base64'));
-
-    var postBody = {
-        url: 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: 'Basic ' + auth,
-        },
-        form: {
-            grant_type: 'refresh_token',
-            refresh_token: this.refreshToken
-        }
-    };
-
-    request.post(postBody, function (e, r, data) {
-        var refreshResponse = JSON.parse(r.body);
-        console.log(refreshResponse);
-        this.refreshToken = refreshResponse.refresh_token;
-        this.token = refreshResponse.access_token;
-        callback(refreshResponse, e);
-    });
-};
-
-
-/**
  * Batch operation to enable an application to perform multiple operations in a single request.
  * The following batch items are supported:
      create


### PR DESCRIPTION
Reverts mcohen01/node-quickbooks#96

Logging the refreshAccessToken to the console as done in #96 presents an exposure risk of unencrypted OAuth 2.0 access tokens, which violates Intuit Security Requirements:

    You must not log any user’s credentials or QuickBooks data.

    Encrypt and store the refresh token and realmId in persistent memory.
