### PR TITLE
Add revoke-access method, and 3 oauth2 endpoints to the endpoint config

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ QuickBooks.prototype.revokeAccess = function(useRefresh, callback) {
             Authorization: 'Basic ' + auth,
         },
         body: JSON.stringify({
-            'token': revokeToken
+            token: revokeToken
         })
     };
 

--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ var OAUTH_ENDPOINTS = {
       var json = JSON.parse(res.body);
       NEW_ENDPOINT_CONFIGURATION.AUTHORIZATION_URL = json.authorization_endpoint;;
       NEW_ENDPOINT_CONFIGURATION.TOKEN_URL = json.token_endpoint;
+      NEW_ENDPOINT_CONFIGURATION.USER_INFO_URL = json.userinfo_endpoint;
+      NEW_ENDPOINT_CONFIGURATION.REVOKE_URL = json.revocation_endpoint;
+      NEW_ENDPOINT_CONFIGURATION.JWKS_URL = json.jwks_url;
       callback(NEW_ENDPOINT_CONFIGURATION);
     });
   }
@@ -129,6 +132,33 @@ QuickBooks.prototype.refreshAccessToken = function(callback) {
     });
 };
 
+/**
+ *
+ * Use either refresh token or bearer token to revoke access. 
+ *
+ * @param useRefresh - boolean - Indicates which token to use: true to use the refresh token or false to use the bearer token
+ * @param {function} callback - Callback function to call with error/response/data results
+ */
+QuickBooks.prototype.revokeAccess = function(useRefresh, callback) {
+    var auth = (new Buffer(this.consumerKey + ':' + this.consumerSecret).toString('base64'));
+    var revokeToken = useRefresh ? this.refreshToken : this.token;
+    var postBody = {
+        url: QuickBooks.REVOKE_URL,
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: 'Basic ' + auth,
+        },
+        body: JSON.stringify({
+            'token': revokeToken
+        })
+    };
+
+    request.post(postBody, function(e, r, data) {
+        callback(e, r, data);
+    });
+};
 /**
  * Batch operation to enable an application to perform multiple operations in a single request.
  * The following batch items are supported:


### PR DESCRIPTION
I've implemented revoke-access per the Intuit documentation in order to satisfy the technical requirements for accountant apps.  
In addition to the revocation endpoint, I added the user-info and jwks endpoints from the discovery document so that they're easily accessible. 
Please forgive the fumbling of commits -- this is the first time I've done a pull request and made a mess of it. I'll be better next time.