### PR TITLE
Replace Moment with date-fns/formatISO

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,15 @@
  * @copyright 2014 Michael Cohen
  */
 
-var request = require('request'),
-    uuid    = require('uuid'),
-    debug   = require('request-debug'),
-    util    = require('util'),
-    moment  = require('moment'),
-    _       = require('underscore'),
-    Promise = require('bluebird'),
-    version = require('./package.json').version,
-    jxon    = require('jxon');
+var request   = require('request'),
+    uuid      = require('uuid'),
+    debug     = require('request-debug'),
+    util      = require('util'),
+    formatISO = require('date-fns/fp/formatISO'),
+    _         = require('underscore'),
+    Promise   = require('bluebird'),
+    version   = require('./package.json').version,
+    jxon      = require('jxon');
 
 module.exports = QuickBooks
 
@@ -220,7 +220,7 @@ QuickBooks.prototype.changeDataCapture = function(entities, since, callback) {
   var url = '/cdc?entities='
   url += typeof entities === 'string' ? entities : entities.join(',')
   url += '&changedSince='
-  url += typeof since === 'string' ? since : moment(since).format()
+  url += typeof since === 'string' ? since : formatISO(since)
   module.request(this, 'get', {url: url}, null, callback)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
+      "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -397,11 +402,6 @@
           "dev": true
         }
       }
-    },
-    "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "oauth-sign": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "3.3.4",
+    "date-fns": "^2.9.0",
     "jxon": "^2.0.0-beta.5",
-    "moment": "^2.19.3",
     "querystring": "0.2.0",
     "request": "2.88.0",
     "request-debug": "0.2.0",


### PR DESCRIPTION
Moment is large, and node-quickbooks is only using it to format a JS Date as an ISO string. date-fns can do that with far less code by directly importing `date-fns/formatISO`.