### PR TITLE
fix: extend unwrap method with response argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -2648,13 +2648,13 @@ module.pluralize = function(s) {
 QuickBooks.prototype.pluralize = module.pluralize
 
 module.unwrap = function(callback, entityName) {
-  if (! callback) return function(err, data) {}
-  return function(err, data) {
+  if (! callback) return function(err, data, res) {}
+  return function(err, data, res) {
     if (err) {
-      if (callback) callback(err)
+      if (callback) callback(err, null, res)
     } else {
       var name = module.capitalize(entityName)
-      if (callback) callback(err, (data || {})[name] || data)
+      if (callback) callback(err, (data || {})[name] || data, res)
     }
   }
 }


### PR DESCRIPTION
Extended `unwrap` method with all callback arguments.
Callback expect 3 arguments [error, body, res], example: https://github.com/mcohen01/node-quickbooks/blob/master/index.js#L2331 but `unwrap` method support only 2 arguments: https://github.com/mcohen01/node-quickbooks/blob/master/index.js#L2652

Because of this it's not possible to get response headers and for example `intuit_tid`, which is required for request form to QBO support.