### PR TITLE
Support retaining the account transaction history on item full update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quickbooks",
-  "version": "2.0.42",
+  "version": "2.0.43",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quickbooks",
-  "version": "2.0.42",
+  "version": "2.0.43",
   "description": "node.js client for Intuit's IPP QuickBooks V3 API.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When you want to update item accounts in Quickbooks then there are two ways how you might want to do that:

* Default behavior is that when item account changes then historical transaction rows are rewritten (ie. item moves from account a to b then all rows containing account a will no longer exist and account b is now used for all those historical rows)
* Behavior what might be needed is that historical rows are kept as is in transactions

Behavior mentioned in last bulletpoint is what the fix is for. From quickbooks documentation: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/item#full-update-an-item

