### PR TITLE
Support for adding extra url params

### DIFF
--- a/index.js
+++ b/index.js
@@ -2340,6 +2340,21 @@ module.request = function(context, verb, options, entity, callback) {
   if (options.url === QuickBooks.RECONNECT_URL || options.url == QuickBooks.DISCONNECT_URL || options.url === QuickBooks.REVOKE_URL || options.url === QuickBooks.USER_INFO_URL) {
     url = options.url
   }
+
+  var urlParams = (entity || {})['addUrlParams'];
+
+  if (urlParams) {
+    const urlObj = new URL(url);
+    const sp = urlObj.searchParams;
+
+    _.forEach(urlParams, (value, key) => {
+      sp.append(key, value);
+    });
+
+    url = urlObj.toString();
+    delete entity.addUrlParams;
+  }
+  
   var opts = {
     url:     url,
     qs:      options.qs || {},


### PR DESCRIPTION
Support for additional URL params in QB calls by using the `addUrlParams` key and passing it an object whose key is the URL param name and value is the URL param value, for example
```
dataForQb.addUrlParams = {
  include: 'enhancedAllCustomFields',
};
```

will result in the following call being made
```
{
   "url": "https://quickbooks.api.intuit.com/v3/company/9341453373192464/invoice?operation=update&include=enhancedAllCustomFields",
   "qs": {
     "minorversion": 73,
     "format": "json"
   },
   "headers": {
     "User-Agent": "node-quickbooks: version 2.0.43",
     "Request-Id": "15b4b7d0-ab16-11ef-a3d2-2fac7251f66f",
     "Authorization": "Bearer *****"
   },
   "json": true,
   "body": {
     "TxnTaxDetail": {
       "TotalTax": 0
     },
     "Line": [
       {
         "DetailType": "SalesItemLineDetail",
         "Description": "CUSTOM",
         "Amount": 1000,
         "SalesItemLineDetail": {
           "ItemRef": {
             "value": "1010000065"
           },
           "Qty": 1,
           "UnitPrice": 1000,
           "TaxCodeRef": {
             "value": "TAX"
           }
         }
       }
     ],
     "TxnDate": "2024-11-24",
     "DocNumber": "IN-10079HZ",
     "PrivateNote": "Houzz Pro Invoice IN-10079HZ",
     "CustomField": [
       {
         "DefinitionId": "1000000021",
         "StringValue": "Partially Paid"
       }
     ],
     "CustomerRef": {
       "value": "8"
     },
     "DepositToAccountRef": {
       "value": "7"
     },
     "BillAddr": {
       "Line1": "Default Client",
       "CountrySubDivisionCode": null,
       "City": null,
       "PostalCode": null,
       "Line2": ""
     },
     "ShipAddr": {
       "Line1": "Default Client",
       "CountrySubDivisionCode": null,
       "City": null,
       "PostalCode": null,
       "Line2": ""
     },
     "Id": "13",
     "SyncToken": "3",
     "sparse": true
   }
 }
```